### PR TITLE
Add RequestType enum values to be passed to Device.Control()

### DIFF
--- a/usb/constants.go
+++ b/usb/constants.go
@@ -147,3 +147,23 @@ var isoUsageTypeDescription = map[IsoUsageType]string{
 func (iut IsoUsageType) String() string {
 	return isoUsageTypeDescription[iut]
 }
+
+type RequestType uint8
+
+const (
+	REQUEST_TYPE_STANDARD = C.LIBUSB_REQUEST_TYPE_STANDARD
+	REQUEST_TYPE_CLASS    = C.LIBUSB_REQUEST_TYPE_CLASS
+	REQUEST_TYPE_VENDOR   = C.LIBUSB_REQUEST_TYPE_VENDOR
+	REQUEST_TYPE_RESERVED = C.LIBUSB_REQUEST_TYPE_RESERVED
+)
+
+var requestTypeDescription = map[RequestType]string{
+	REQUEST_TYPE_STANDARD: "standard",
+	REQUEST_TYPE_CLASS:    "class",
+	REQUEST_TYPE_VENDOR:   "vendor",
+	REQUEST_TYPE_RESERVED: "reserved",
+}
+
+func (rt RequestType) String() string {
+	return requestTypeDescription[rt]
+}


### PR DESCRIPTION
Hi Kyle,

I have been writing a small utility for [Crazyflie](http://wiki.bitcraze.se/projects:crazyflie:index) quadrocopter and I have to pass a few missing constants to Device.Control.

I feel that these constants might be useful for other people using gousb as well, so I have decided to send this CL.

Please, review. Feel free to request any changes, if you feel that my code does not look right, violates the project style conventions or anything else.
