### PR TITLE
Allow opening multiple endpoints for the same device

### DIFF
--- a/usb/device.go
+++ b/usb/device.go
@@ -157,8 +157,14 @@ func (d *Device) OpenEndpoint(conf, iface, setup, epoint uint8) (Endpoint, error
 found:
 
 	// Set the configuration
-	if errno := C.libusb_set_configuration(d.handle, C.int(conf)); errno < 0 {
-		return nil, fmt.Errorf("usb: setcfg: %s", usbError(errno))
+	var activeConf C.int
+	if errno := C.libusb_get_configuration(d.handle, &activeConf); errno < 0 {
+		return nil, fmt.Errorf("usb: getcfg: %s", usbError(errno))
+	}
+	if int(activeConf) != int(conf) {
+		if errno := C.libusb_set_configuration(d.handle, C.int(conf)); errno < 0 {
+			return nil, fmt.Errorf("usb: setcfg: %s", usbError(errno))
+		}
 	}
 
 	// Claim the interface


### PR DESCRIPTION
This CL fixes the case when you have to open two (or more) endpoints for the same device, interface and configuration. In my case, the device had two endpoints:

```
002.034 1915:7777 Unknown (Nordic Semiconductor ASA)
  Protocol: (Defined at Interface level)
  Config 01:
    --------------
    Interface 00 Setup 00
      Vendor Specific Class (Vendor Specific Subclass)
      Endpoint 1 IN  bulk - unsynchronized data [64 0]
      Endpoint 1 OUT bulk - unsynchronized data [64 0]
    --------------
```

or, alternatively

```
found setup:
usb.InterfaceSetup{
  Number:0x0, Alternate:0x0, IfClass:0xff, IfSubClass:0xff, IfProtocol:0x0,
  Endpoints:[]usb.EndpointInfo{
    usb.EndpointInfo{
      Address:0x81, Attributes:0x2, MaxPacketSize:0x40, MaxIsoPacket:0x0,
      PollInterval:0x6, RefreshRate:0x0, SynchAddress:0x0
    },
    usb.EndpointInfo{
      Address:0x1, Attributes:0x2, MaxPacketSize:0x40, MaxIsoPacket:0x0,
      PollInterval:0x6, RefreshRate:0x0, SynchAddress:0x0
    }
  }
}
```

one endpoint is IN, another is OUT; so, in order to communicate with my quadrocopter, I have to open both endpoints. Since Device.OpenEndpoint calls libusb_set_configuration, it fails on the second time, since the device has already an interface claimed.

This is a standard issue with libusb, and it has a dedicated section on the libusb website: [libusb: Caveats -- Configuration selection and handling](http://libusb.sourceforge.net/api-1.0/caveats.html#configsel).

I hope this patch would be helpful for anyone with two-ways usb devices, but I might be wrong, of course.
