### PR TITLE
Hotplug

### DIFF
--- a/usb/hotplug.c
+++ b/usb/hotplug.c
@@ -1,0 +1,17 @@
+#include <libusb-1.0/libusb.h>
+#include "_cgo_export.h"
+
+int attachCallback(
+	libusb_context* ctx,
+	libusb_hotplug_event events,
+	libusb_hotplug_flag flags,
+	int vid,
+	int pid,
+	int dev_class,
+	void* user_data,
+	libusb_hotplug_callback_handle* handle
+) {
+	return libusb_hotplug_register_callback(
+		ctx, events, flags, vid, pid, dev_class, (libusb_hotplug_callback_fn)(goCallback), user_data, handle
+	);
+}

--- a/usb/hotplug.go
+++ b/usb/hotplug.go
@@ -89,6 +89,8 @@ func (ctx *Context) RegisterHotplugCallback(vendor_id int, product_id int, class
 }
 
 func (ctx *Context) DeregisterHotplugCallback(handle HotplugHandle) {
+	mutexHotplugCallbackMap.Lock()
+	defer mutexHotplugCallbackMap.Unlock()
 	C.libusb_hotplug_deregister_callback(ctx.ctx, C.libusb_hotplug_callback_handle(handle))
 	delete(hotplugCallbackMap, handle)
 }

--- a/usb/hotplug.go
+++ b/usb/hotplug.go
@@ -1,0 +1,94 @@
+package usb
+
+/*
+#include <libusb-1.0/libusb.h>
+
+extern int attachCallback(
+	libusb_context* ctx,
+	libusb_hotplug_event events,
+	libusb_hotplug_flag flags,
+	int vid,
+	int pid,
+	int dev_class,
+	void* user_data,
+	libusb_hotplug_callback_handle* handle
+);
+*/
+import "C"
+
+import (
+	"unsafe"
+	"sync"
+)
+
+type (
+	HotplugEvent C.int
+	HotplugHandle C.libusb_hotplug_callback_handle
+	HotplugCallback func(desc *Descriptor, event HotplugEvent) bool
+)
+
+type hotplugCallbackData struct {
+   f HotplugCallback  // The user's function pointer
+   d interface{}      // The user's userdata.
+}
+
+const (
+	HOTPLUG_EVENT_DEVICE_ARRIVED HotplugEvent = C.LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED
+	HOTPLUG_EVENT_DEVICE_LEFT    HotplugEvent = C.LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT
+	HOTPLUG_ANY                  int = C.LIBUSB_HOTPLUG_MATCH_ANY
+)
+
+var (
+	hotplugCallbackMap      map[HotplugHandle]*hotplugCallbackData
+	mutexHotplugCallbackMap sync.Mutex
+)
+
+func init() {
+	hotplugCallbackMap = make(map[HotplugHandle]*hotplugCallbackData)
+}
+
+//export goCallback
+func goCallback(ctx unsafe.Pointer, device unsafe.Pointer, event int, userdata unsafe.Pointer) C.int {
+	realCallback := (*hotplugCallbackData)(userdata)
+	descriptor, err := newDescriptor((*C.libusb_device)(device))
+	if err != nil {
+		// TODO: what to do here? add an error callback?
+		panic("error happened in callback")
+		//return 0
+	}
+	if realCallback.f(descriptor, HotplugEvent(event)) {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+func (ctx *Context) RegisterHotplugCallback(vendor_id int, product_id int, class int, callback HotplugCallback, events HotplugEvent, enumerate bool) (HotplugHandle, error) {
+	mutexHotplugCallbackMap.Lock()
+	defer mutexHotplugCallbackMap.Unlock()
+	var handle HotplugHandle
+	data := hotplugCallbackData{
+		f: callback,
+	}
+	dataPtr := unsafe.Pointer(&data)
+
+	var enumflag C.libusb_hotplug_flag
+	if enumerate {
+		enumflag = 1
+	} else {
+		enumflag = 0
+	}
+
+	res := C.attachCallback(ctx.ctx, C.libusb_hotplug_event(events), enumflag, C.int(vendor_id), C.int(product_id), C.int(class), dataPtr, (*C.libusb_hotplug_callback_handle)(&handle))
+	if res != C.LIBUSB_SUCCESS {
+		return 0, usbError(res)
+	}
+	// protect the data from the garbage collector
+	hotplugCallbackMap[handle] = &data
+	return handle, nil
+}
+
+func (ctx *Context) DeregisterHotplugCallback(handle HotplugHandle) {
+	C.libusb_hotplug_deregister_callback(ctx.ctx, C.libusb_hotplug_callback_handle(handle))
+	delete(hotplugCallbackMap, handle)
+}

--- a/usb/hotplug.go
+++ b/usb/hotplug.go
@@ -17,26 +17,26 @@ extern int attachCallback(
 import "C"
 
 import (
-	"unsafe"
 	"sync"
+	"unsafe"
 )
 
 type (
-	HotplugEvent C.int
-	HotplugHandle C.libusb_hotplug_callback_handle
+	HotplugEvent    C.int
+	HotplugHandle   C.libusb_hotplug_callback_handle
 	HotplugCallback func(desc *Descriptor, event HotplugEvent) bool
 )
 
 type hotplugCallbackData struct {
-	f HotplugCallback  // The user's function pointer
-	d interface{}      // The user's userdata.
-	h HotplugHandle    // the handle belonging to this callback
+	f HotplugCallback // The user's function pointer
+	d interface{}     // The user's userdata.
+	h HotplugHandle   // the handle belonging to this callback
 }
 
 const (
 	HOTPLUG_EVENT_DEVICE_ARRIVED HotplugEvent = C.LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED
 	HOTPLUG_EVENT_DEVICE_LEFT    HotplugEvent = C.LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT
-	HOTPLUG_ANY                  int = C.LIBUSB_HOTPLUG_MATCH_ANY
+	HOTPLUG_ANY                  int          = C.LIBUSB_HOTPLUG_MATCH_ANY
 )
 
 var (

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -38,6 +38,7 @@ func (c *Context) Debug(level int) {
 func NewContext() *Context {
 	c := &Context{
 		done: make(chan struct{}),
+		yield: make(chan struct{}),
 	}
 
 	if errno := C.libusb_init(&c.ctx); errno != 0 {

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -26,8 +26,8 @@ import (
 )
 
 type Context struct {
-	ctx  *C.libusb_context
-	done chan struct{}
+	ctx   *C.libusb_context
+	done  chan struct{}
 	yield chan struct{}
 }
 

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -26,9 +26,10 @@ import (
 )
 
 type Context struct {
-	ctx   *C.libusb_context
-	done  chan struct{}
-	yield chan struct{}
+	ctx              *C.libusb_context
+	done             chan struct{}
+	yield            chan struct{}
+	hotplugCallbacks hotplugCallbackMap
 }
 
 func (c *Context) Debug(level int) {
@@ -37,7 +38,7 @@ func (c *Context) Debug(level int) {
 
 func NewContext() *Context {
 	c := &Context{
-		done: make(chan struct{}),
+		done:  make(chan struct{}),
 		yield: make(chan struct{}),
 	}
 


### PR DESCRIPTION
You can use it like this:

``` go
func Hotplugged(desc *usb.Descriptor, event usb.HotplugEvent) bool {
    return false
}

handle, err := ctx.RegisterHotplugCallback(usb.HOTPLUG_ANY, usb.HOTPLUG_ANY, usb.HOTPLUG_ANY,
    Hotplugged,
    usb.HOTPLUG_EVENT_DEVICE_ARRIVED | usb.HOTPLUG_EVENT_DEVICE_LEFT,
    true,
)
```

Returning true in the callback will deregister it.

I also added a HandleEvents method to Context, because if your main loop is an infinite loop, the scheduler will never schedule to goroutine inside usb.go. Alternatively, you can use runtime.Gosched to give it a chance to run.
