### PR TITLE
Detach linux kernel driver if necessary

### DIFF
--- a/usb/device.go
+++ b/usb/device.go
@@ -43,9 +43,12 @@ type Device struct {
 	// Claimed interfaces
 	lock    *sync.Mutex
 	claimed map[uint8]int
+
+	// Detached kernel interfaces
+	detached map[uint8]int
 }
 
-func newDevice(handle *C.libusb_device_handle, desc *Descriptor) *Device {
+func newDevice(handle *C.libusb_device_handle, desc *Descriptor) (*Device, error) {
 	ifaces := 0
 	d := &Device{
 		handle:         handle,
@@ -55,9 +58,66 @@ func newDevice(handle *C.libusb_device_handle, desc *Descriptor) *Device {
 		ControlTimeout: DefaultControlTimeout,
 		lock:           new(sync.Mutex),
 		claimed:        make(map[uint8]int, ifaces),
+		detached:       make(map[uint8]int),
 	}
 
-	return d
+	if err := d.detachKernelDriver(); err != nil {
+		d.Close()
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// detachKernelDriver detaches any active kernel drivers, if supported by the platform.
+// If there are any errors, like Context.ListDevices, only the final one will be returned.
+func (d *Device) detachKernelDriver() (err error) {
+	for _, cfg := range d.Configs {
+		for _, iface := range cfg.Interfaces {
+			switch activeErr := C.libusb_kernel_driver_active(d.handle, C.int(iface.Number)); activeErr {
+			case C.LIBUSB_ERROR_NOT_SUPPORTED:
+				// no need to do any futher checking, no platform support
+				return
+			case 0:
+				continue
+			case 1:
+				switch detachErr := C.libusb_detach_kernel_driver(d.handle, C.int(iface.Number)); detachErr {
+				case C.LIBUSB_ERROR_NOT_SUPPORTED:
+					// shouldn't ever get here, should be caught by the outer switch
+					return
+				case 0:
+					d.detached[iface.Number]++
+				case C.LIBUSB_ERROR_NOT_FOUND:
+					// this status is returned if libusb's driver is already attached to the device
+					d.detached[iface.Number]++
+				default:
+					err = fmt.Errorf("usb: detach kernel driver: %s", usbError(detachErr))
+				}
+			default:
+				err = fmt.Errorf("usb: active kernel driver check: %s", usbError(activeErr))
+			}
+		}
+	}
+
+	return
+}
+
+// attachKernelDriver re-attaches kernel drivers to any previously detached interfaces, if supported by the platform.
+// If there are any errors, like Context.ListDevices, only the final one will be returned.
+func (d *Device) attachKernelDriver() (err error) {
+	for iface := range d.detached {
+		switch attachErr := C.libusb_attach_kernel_driver(d.handle, C.int(iface)); attachErr {
+		case C.LIBUSB_ERROR_NOT_SUPPORTED:
+			// no need to do any futher checking, no platform support
+			return
+		case 0:
+			continue
+		default:
+			err = fmt.Errorf("usb: attach kernel driver: %s", usbError(attachErr))
+		}
+	}
+
+	return
 }
 
 func (d *Device) Reset() error {
@@ -115,6 +175,7 @@ func (d *Device) Close() error {
 	for iface := range d.claimed {
 		C.libusb_release_interface(d.handle, C.int(iface))
 	}
+	d.attachKernelDriver()
 	C.libusb_close(d.handle)
 	d.handle = nil
 	return nil

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -100,7 +100,11 @@ func (c *Context) ListDevices(each func(desc *Descriptor) bool) ([]*Device, erro
 				reterr = err
 				continue
 			}
-			ret = append(ret, newDevice(handle, desc))
+			if dev, err := newDevice(handle, desc); err != nil {
+				reterr = err
+			} else {
+				ret = append(ret, dev)
+			}
 		}
 	}
 	return ret, reterr


### PR DESCRIPTION
On Linux, some devices require detaching the kernel driver before attempting to use the device.
