### PR TITLE
Return non-nil error if libusb_open fails

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -20,6 +20,7 @@ package usb
 import "C"
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 	"unsafe"
@@ -97,7 +98,7 @@ func (c *Context) ListDevices(each func(desc *Descriptor) bool) ([]*Device, erro
 		if each(desc) {
 			var handle *C.libusb_device_handle
 			if errno := C.libusb_open(dev, &handle); errno != 0 {
-				reterr = err
+				reterr = fmt.Errorf("libusb_open returned errno: %d", errno)
 				continue
 			}
 			ret = append(ret, newDevice(handle, desc))


### PR DESCRIPTION
When errno is not 0, the variable 'err' is returned - however,
this was defined above as the return value from newDescriptor,
which will always be nil.
