### PR TITLE
ENDPOINT_NUM_MASK should be 0x0f

### DIFF
--- a/usb/constants.go
+++ b/usb/constants.go
@@ -86,7 +86,7 @@ func (dt DescriptorType) String() string {
 type EndpointDirection uint8
 
 const (
-	ENDPOINT_NUM_MASK                   = 0x03
+	ENDPOINT_NUM_MASK                   = 0x0f
 	ENDPOINT_DIR_IN   EndpointDirection = C.LIBUSB_ENDPOINT_IN
 	ENDPOINT_DIR_OUT  EndpointDirection = C.LIBUSB_ENDPOINT_OUT
 	ENDPOINT_DIR_MASK EndpointDirection = 0x80


### PR DESCRIPTION
Reference http://developer.android.com/reference/android/hardware/usb/UsbConstants.html#USB_ENDPOINT_NUMBER_MASK
