### PR TITLE
Rawread improvements

### DIFF
--- a/usb/constants.go
+++ b/usb/constants.go
@@ -87,7 +87,7 @@ func (dt DescriptorType) String() string {
 type EndpointDirection uint8
 
 const (
-	ENDPOINT_NUM_MASK                   = 0x03
+	ENDPOINT_NUM_MASK                   = 0x0f
 	ENDPOINT_DIR_IN   EndpointDirection = C.LIBUSB_ENDPOINT_IN
 	ENDPOINT_DIR_OUT  EndpointDirection = C.LIBUSB_ENDPOINT_OUT
 	ENDPOINT_DIR_MASK EndpointDirection = 0x80

--- a/usb/iso.c
+++ b/usb/iso.c
@@ -74,8 +74,8 @@ int extract_data(struct libusb_transfer *xfer, void *raw, int max, unsigned char
 
 		// Copy the data
 		int len = pkt.actual_length;
-		if (len > max) {
-			len = max;
+		if (copied + len > max) {
+			len = max - copied;
 		}
 		memcpy(out, in, len);
 		copied += len;
@@ -84,10 +84,14 @@ int extract_data(struct libusb_transfer *xfer, void *raw, int max, unsigned char
 		in += pkt.length;
 		out += len;
 
+        if (copied == max) {
+                break;
+        }
+
 		// Extract first error
 		if (pkt.status == 0 || *status != 0) {
 			continue;
-		}	
+		}
 		*status = pkt.status;
 	}
 	return copied;

--- a/usb/iso.go
+++ b/usb/iso.go
@@ -45,10 +45,6 @@ func (end *endpoint) allocTransfer(maxLen int) *Transfer {
 	if numIsoPackets*int(isoPacketSize) < maxLen {
 		numIsoPackets++
 	}
-	// arbitrary limit
-	if numIsoPackets > 200 {
-		numIsoPackets = 200
-	}
 	xfer := C.libusb_alloc_transfer(C.int(numIsoPackets))
 	if xfer == nil {
 		log.Printf("usb: transfer allocation failed?!")

--- a/usb/iso.go
+++ b/usb/iso.go
@@ -37,18 +37,25 @@ func iso_callback(cptr unsafe.Pointer) {
 	close(ch)
 }
 
-func (end *endpoint) allocTransfer() *Transfer {
-	const (
-		iso_packets = 8 // 128 // 242
-	)
-
-	xfer := C.libusb_alloc_transfer(C.int(iso_packets))
+func (end *endpoint) allocTransfer(maxLen int) *Transfer {
+	isoPacketSize := end.EndpointInfo.MaxIsoPacket
+	// the larget the input buffer, the more packets we use in a single
+	// transfer.
+	numIsoPackets := maxLen / int(isoPacketSize)
+	if numIsoPackets*int(isoPacketSize) < maxLen {
+		numIsoPackets++
+	}
+	// arbitrary limit
+	if numIsoPackets > 200 {
+		numIsoPackets = 200
+	}
+	xfer := C.libusb_alloc_transfer(C.int(numIsoPackets))
 	if xfer == nil {
 		log.Printf("usb: transfer allocation failed?!")
 		return nil
 	}
 
-	buf := make([]byte, iso_packets*end.EndpointInfo.MaxIsoPacket)
+	buf := make([]byte, numIsoPackets*int(end.EndpointInfo.MaxIsoPacket))
 	done := make(chan struct{}, 1)
 
 	xfer.dev_handle = end.Device.handle
@@ -57,7 +64,7 @@ func (end *endpoint) allocTransfer() *Transfer {
 
 	xfer.buffer = (*C.uchar)((unsafe.Pointer)(&buf[0]))
 	xfer.length = C.int(len(buf))
-	xfer.num_iso_packets = iso_packets
+	xfer.num_iso_packets = C.int(numIsoPackets)
 
 	C.libusb_set_iso_packet_lengths(xfer, C.uint(end.EndpointInfo.MaxIsoPacket))
 	/*
@@ -130,7 +137,7 @@ func (t *Transfer) Close() error {
 }
 
 func isochronous_xfer(e *endpoint, buf []byte, timeout time.Duration) (int, error) {
-	t := e.allocTransfer()
+	t := e.allocTransfer(len(buf))
 	defer t.Close()
 
 	if err := t.Submit(timeout); err != nil {


### PR DESCRIPTION
@kylelemons 
Actually read some data. Print out the collected data in a single-read mode.
Add a benchmark option that keeps reading and periodically reports the throughput.
Update iso code to use the length of the user-specified buffer as the basis for calculating number of iso transfers and for limiting the amount of returned data.