### PR TITLE
Don't assume libusb headers are always in libusb-1.0.

### DIFF
--- a/usb/config.go
+++ b/usb/config.go
@@ -15,7 +15,7 @@
 
 package usb
 
-// #include <libusb-1.0/libusb.h>
+// #include <libusb.h>
 import "C"
 
 import (

--- a/usb/constants.go
+++ b/usb/constants.go
@@ -15,7 +15,7 @@
 
 package usb
 
-// #include <libusb-1.0/libusb.h>
+// #include <libusb.h>
 import "C"
 
 type Class uint8

--- a/usb/descriptor.go
+++ b/usb/descriptor.go
@@ -15,7 +15,7 @@
 
 package usb
 
-// #include <libusb-1.0/libusb.h>
+// #include <libusb.h>
 import "C"
 
 type Descriptor struct {

--- a/usb/device.go
+++ b/usb/device.go
@@ -15,7 +15,7 @@
 
 package usb
 
-// #include <libusb-1.0/libusb.h>
+// #include <libusb.h>
 import "C"
 
 import (

--- a/usb/endpoint.go
+++ b/usb/endpoint.go
@@ -15,7 +15,7 @@
 
 package usb
 
-// #include <libusb-1.0/libusb.h>
+// #include <libusb.h>
 import "C"
 
 import (

--- a/usb/error.go
+++ b/usb/error.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 )
 
-// #include <libusb-1.0/libusb.h>
+// #include <libusb.h>
 import "C"
 
 type usbError C.int

--- a/usb/iso.c
+++ b/usb/iso.c
@@ -27,7 +27,7 @@ void callback(struct libusb_transfer *xfer) {
 }
 
 int submit(struct libusb_transfer *xfer) {
-	xfer->callback = &callback;
+	xfer->callback = (libusb_transfer_cb_fn)(&callback);
 	xfer->status = -1;
 	//print_xfer(xfer);
 	//printf("Transfer submitted\n");

--- a/usb/iso.c
+++ b/usb/iso.c
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/usb/iso.go
+++ b/usb/iso.go
@@ -16,7 +16,7 @@
 package usb
 
 /*
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 int submit(struct libusb_transfer *xfer);
 void print_xfer(struct libusb_transfer *xfer);

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -16,11 +16,8 @@
 // Package usb provides a wrapper around libusb-1.0.
 package usb
 
-// #cgo windows CFLAGS: -ID:/lib/libusb-1.0.19/include
-// #cgo windows,amd64 LDFLAGS: D:/lib/libusb-1.0.19/MinGW64/static/libusb-1.0.a
-// #cgo windows,386 LDFLAGS: D:/lib/libusb-1.0.19/MinGW32/static/libusb-1.0.a
-// #cgo !windows LDFLAGS: -lusb-1.0
-// #include <libusb-1.0/libusb.h>
+// #cgo pkg-config: libusb-1.0
+// #include <libusb.h>
 import "C"
 
 import (


### PR DESCRIPTION
Use pkg-config to add correct include paths for libusb regardless of the
platform.

@kylelemons this also replaces the hardcoded paths for win32/win64 and moves from static linking to dynamic linking. I'm not super familiar with development in mingw, so I have no idea whether setting up pkg-config in mingw is something you'd typically do. But in general it's supported - I've successfuly built and ran lsusb on a freshly set up windows server core 2012 with mingw and libusb.