### PR TITLE
Remove context close race condition

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -133,7 +133,7 @@ func (c *Context) OpenDeviceWithVidPid(vid, pid int) (*Device, error) {
 }
 
 func (c *Context) Close() error {
-	close(c.done)
+	c.done <- struct{}{}
 	if c.ctx != nil {
 		C.libusb_exit(c.ctx)
 	}


### PR DESCRIPTION
When terminating the Context, wait for the background goroutine
to sync on c.done channel before exiting.

Addresses issue #37 