### PR TITLE
Change the iso packet size if the buffer is very small.

### DIFF
--- a/usb/device.go
+++ b/usb/device.go
@@ -124,6 +124,7 @@ func (d *Device) OpenEndpoint(cfgNum, ifNum, setNum, epNum uint8) (Endpoint, err
 			setAlternate = i != 0
 			debug.Printf("found setup: %#v [default: %v]\n", s, !setAlternate)
 			ifs = &s
+			break
 		}
 	}
 	if ifs == nil {
@@ -135,6 +136,7 @@ func (d *Device) OpenEndpoint(cfgNum, ifNum, setNum, epNum uint8) (Endpoint, err
 		if e.Address == epNum {
 			debug.Printf("found ep %02x in %#v\n", epNum, *ifs)
 			ep = &e
+			break
 		}
 	}
 	if ep == nil {

--- a/usb/endpoint_test.go
+++ b/usb/endpoint_test.go
@@ -126,9 +126,9 @@ func TestOpenEndpoint(t *testing.T) {
 	}
 	i := ep.Info()
 	if got, want := i.Address, uint8(0x86); got != want {
-		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=2, ep=0x86): ep.Info.Address = %x, want %x", got, want)
+		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=1, ep=0x86): ep.Info.Address = %x, want %x", got, want)
 	}
 	if got, want := i.MaxIsoPacket, uint32(2*1024); got != want {
-		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=2, ep=0x86): ep.Info.MaxIsoPacket = %d, want %d", got, want)
+		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=1, ep=0x86): ep.Info.MaxIsoPacket = %d, want %d", got, want)
 	}
 }

--- a/usb/endpoint_test.go
+++ b/usb/endpoint_test.go
@@ -120,15 +120,15 @@ func TestOpenEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDeviceWithVidPid(0x8888, 0x0002): got error %v, want nil", err)
 	}
-	ep, err := dev.OpenEndpoint(1, 1, 2, 0x86)
+	ep, err := dev.OpenEndpoint(1, 1, 1, 0x86)
 	if err != nil {
-		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=2, ep=0x86): got error %v, want nil", err)
+		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=1, ep=0x86): got error %v, want nil", err)
 	}
 	i := ep.Info()
 	if got, want := i.Address, uint8(0x86); got != want {
 		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=2, ep=0x86): ep.Info.Address = %x, want %x", got, want)
 	}
-	if got, want := i.MaxIsoPacket, uint32(1024); got != want {
+	if got, want := i.MaxIsoPacket, uint32(2*1024); got != want {
 		t.Errorf("OpenEndpoint(cfg=1, if=1, alt=2, ep=0x86): ep.Info.MaxIsoPacket = %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
Previously number of iso packets could have amounted to a transfer buffer
larger than passed buffer, which could lead to overflow.

Now the number of bytes requested from device is always smaller or equal
to the buffer size.

In theory, it could lead to inefficiencies in transfer: if max packet
size is 1024 and user request 2046 bytes of data, transfer will return at most
1024 bytes, while it could use a more efficient 2 packets of 1023 bytes.
But at least it's correct now. It seems that for efficiency the user would
always use the reported max packet size anyway.

The device could still send more data than requested, but libusb takes
care of it.