### PR TITLE
Bugfix: abort loop to avoid clobbering variable

### DIFF
--- a/usb/device.go
+++ b/usb/device.go
@@ -135,6 +135,7 @@ func (d *Device) OpenEndpoint(cfgNum, ifNum, setNum, epNum uint8) (Endpoint, err
 		if e.Address == epNum {
 			debug.Printf("found ep %02x in %#v\n", epNum, *ifs)
 			ep = &e
+			break
 		}
 	}
 	if ep == nil {


### PR DESCRIPTION
Before this commit, OpenEndpoint() would open the wrong endpoint on my
machine.